### PR TITLE
Add bounds for pydantic version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 jsonschema==3.2.0
 python-dateutil==2.8.1
 inflection==0.5.1
-pydantic==1.8.2
+pydantic>=1.6.2,!=1.7,!=1.7.1,!=1.7.2,!=1.7.3,!=1.8,!=1.8.1,<2.0.0


### PR DESCRIPTION
This PR will allow us to use latest version of pydantic (with vulnerabilities patched) without making a new release